### PR TITLE
move geometry checks into step_to_brep tool and add fixup option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,7 @@ occt_libs = [
   'TKBO', 'TKBRep', 'TKPrim',
   'TKG3d', 'TKLCAF', 'TKMath',
   'TKTopAlgo', 'TKXCAF', 'TKSTEP',
-  'TKXSBase', 'TKXDESTEP',
+  'TKXSBase', 'TKXDESTEP', 'TKShHealing'
 ]
 
 occt_deps = []

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -464,7 +464,6 @@ imprint_result perform_solid_imprinting(
 	{
 		boolean_op op{filler, BOPAlgo_COMMON, shape, tool};
 		op.SetFuzzyValue(filler.FuzzyValue());
-		op.SimplifyResult();
 		op.Build();
 		collect_warnings(op.GetReport().get(), result.num_common_warnings);
 		if (op.HasErrors()) {
@@ -501,11 +500,9 @@ imprint_result perform_solid_imprinting(
 			merge_into_shape ? result.shape : result.tool,
 			common
 		};
-		op.SimplifyResult();
 		// fuzzy stuff has already been done so no need to introduce more error
 		// op.SetFuzzyValue(filler.FuzzyValue());
 		// the above created distinct shapes, so we are free to modify here
-		op.SetNonDestructive(false);
 
 		op.Build();
 		collect_warnings(op.GetReport().get(), result.num_fuse_warnings);

--- a/src/overlap_checker.cpp
+++ b/src/overlap_checker.cpp
@@ -181,7 +181,6 @@ main(int argc, char **argv)
 
 	std::string path_in;
 	unsigned num_parallel_jobs;
-	bool perform_geometry_checks{true};
 	double
 		bbox_clearance = 0.5,
 		max_common_volume_ratio = 0.01;
@@ -200,10 +199,6 @@ main(int argc, char **argv)
 			->option_text("N")
 			->default_val(4)
 			->check(CLI::Range(1, 1024));
-		app.add_flag(
-			"--check-geometry,!--no-check-geometry",
-			perform_geometry_checks,
-			"Check overall validity of shapes");
 		app.add_option(
 			"--bbox-clearance", bbox_clearance,
 			"Bounding-boxes closer than C will be checked for overlaps")
@@ -255,16 +250,6 @@ main(int argc, char **argv)
 
 	document doc;
 	doc.load_brep_file(path_in.c_str());
-
-	if (perform_geometry_checks) {
-		spdlog::debug("checking geometry");
-		auto ninvalid = doc.count_invalid_shapes();
-		if (ninvalid) {
-			spdlog::critical("{} shapes were not valid", ninvalid);
-			return 1;
-		}
-		spdlog::info("geometry checks passed");
-	}
 
 	spdlog::debug("calculating bounding boxes");
 	std::vector<Bnd_OBB> bounding_boxes;


### PR DESCRIPTION
might be worth actually having a separate tool for doing these things, but this feels like a better place to put them than in the `overlap_checker` tool where they were