### PR TITLE
report progress during expensive operations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ link_libraries(
   TKTopAlgo TKXCAF TKSTEP
   TKXSBase TKXDESTEP TKShHealing)
 
-add_library(shared OBJECT utils.cpp geometry.cpp)
+add_library(shared OBJECT utils.cpp geometry.cpp thread_pool.cpp)
 
 add_executable(step_to_brep step_to_brep.cpp $<TARGET_OBJECTS:shared>)
 
@@ -20,9 +20,9 @@ add_executable(imprint_solids imprint_solids.cpp $<TARGET_OBJECTS:shared>)
 
 
 if(BUILD_TESTING)
-  add_executable(test_runner geometry.cpp utils.cpp)
+  add_executable(test_runner geometry.cpp utils.cpp thread_pool.cpp)
   target_compile_definitions(test_runner PUBLIC -DINCLUDE_TESTS)
-  target_link_libraries(test_runner Catch2WithMain)
+  target_link_libraries(test_runner pthread Catch2WithMain)
 
   add_test(NAME unit-tests COMMAND test_runner)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,10 +9,11 @@ link_libraries(
 
 add_library(shared OBJECT utils.cpp geometry.cpp thread_pool.cpp)
 
+link_libraries(pthread)
+
 add_executable(step_to_brep step_to_brep.cpp $<TARGET_OBJECTS:shared>)
 
 add_executable(overlap_checker overlap_checker.cpp $<TARGET_OBJECTS:shared>)
-target_link_libraries(overlap_checker pthread)
 
 add_executable(overlap_collecter overlap_collecter.cpp $<TARGET_OBJECTS:shared>)
 
@@ -22,7 +23,7 @@ add_executable(imprint_solids imprint_solids.cpp $<TARGET_OBJECTS:shared>)
 if(BUILD_TESTING)
   add_executable(test_runner geometry.cpp utils.cpp thread_pool.cpp)
   target_compile_definitions(test_runner PUBLIC -DINCLUDE_TESTS)
-  target_link_libraries(test_runner pthread Catch2WithMain)
+  target_link_libraries(test_runner Catch2WithMain)
 
   add_test(NAME unit-tests COMMAND test_runner)
 endif()

--- a/src/overlap_checker.cpp
+++ b/src/overlap_checker.cpp
@@ -238,7 +238,7 @@ main(int argc, char **argv)
 					continue;
 				}
 
-				map.apply(pool, [&state, hi, lo]() {
+				map.submit(pool, [&state, hi, lo]() {
 					return shape_classifier(state, hi, lo);
 				});
 				num_to_process += 1;

--- a/src/overlap_checker.cpp
+++ b/src/overlap_checker.cpp
@@ -35,7 +35,7 @@ struct worker_output {
 };
 
 static worker_output
-shape_classifier(worker_state& state, size_t hi, size_t lo)
+shape_classifier(const worker_state& state, size_t hi, size_t lo)
 {
 	const auto &shape = state.doc.solid_shapes[hi];
 	const auto &tool = state.doc.solid_shapes[lo];
@@ -224,7 +224,7 @@ main(int argc, char **argv)
 		num_bad_overlaps = 0;
 
 	{
-		struct worker_state state{doc, imprint_tolerances};
+		const struct worker_state state{doc, imprint_tolerances};
 		asyncmap<worker_output> map;
 
 		for (size_t hi = 1; hi < doc.solid_shapes.size(); hi++) {

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -1,0 +1,93 @@
+#include "thread_pool.hpp"
+
+#ifdef INCLUDE_TESTS
+#include <catch2/catch_test_macros.hpp>
+#endif
+
+thread_pool::thread_pool(size_t num_workers) : running(true)
+{
+	for (size_t i = 0; i < num_workers; i++) {
+		workers.emplace_back(&thread_pool::worker, this);
+	}
+}
+
+thread_pool::~thread_pool()
+{
+	running = false;
+
+	for (auto &worker : workers) {
+		// I think I might be able to get away with doing this once! but
+		// given the costs it doesn't seem worth it
+		cond.notify_all();
+
+		worker.join();
+	}
+}
+
+void thread_pool::worker()
+{
+	std::unique_lock<std::mutex> mlock(mutex);
+
+	while(running) {
+		if (queue.empty()) {
+			cond.wait(mlock);
+			continue;
+		}
+
+		auto task = queue.front();
+		queue.pop_front();
+		mlock.unlock();
+		task();
+		mlock.lock();
+	}
+}
+
+void thread_pool::submit(std::function<void(void)> task)
+{
+	std::unique_lock<std::mutex> mlock(mutex);
+
+	queue.emplace_back(task);
+	mlock.unlock();
+
+	cond.notify_one();
+}
+
+
+#ifdef INCLUDE_TESTS
+TEST_CASE("thread_pool") {
+	thread_pool pool(1);
+
+	SECTION("parfor waits") {
+		parfor work;
+		bool completed = false;
+		// submit a simple job
+		work.submit(pool, [&completed]() {
+			completed = true;
+		});
+		// wait for them all to complete
+		work.wait();
+		// make sure our job ran
+		CHECK(completed);
+	};
+
+	SECTION("asyncmap") {
+		asyncmap<int> map;
+		constexpr int N = 5;
+		// run a few jobs asynchronously
+		for (size_t i = 0; i < N; i++) {
+			map.apply(pool, [i]() {
+				return i;
+			});
+		}
+		// collect their results
+		int done[N] = {};
+		while (!map.empty()) {
+			done[map.get()] += 1;
+		}
+		// make sure they all ran once
+		for (int d : done) {
+			CHECK(d == 1);
+		}
+	};
+}
+#endif

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -75,7 +75,7 @@ TEST_CASE("thread_pool") {
 		constexpr int N = 5;
 		// run a few jobs asynchronously
 		for (size_t i = 0; i < N; i++) {
-			map.apply(pool, [i]() {
+			map.submit(pool, [i]() {
 				return i;
 			});
 		}

--- a/src/thread_pool.hpp
+++ b/src/thread_pool.hpp
@@ -1,0 +1,114 @@
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <thread>
+#include <mutex>
+#include <vector>
+
+
+class thread_pool {
+	std::vector<std::thread> workers;
+
+	std::mutex mutex;
+	std::condition_variable cond;
+	std::deque<std::function<void(void)>> queue;
+	bool running;
+
+	void worker();
+
+public:
+	thread_pool(size_t num_workers);
+	virtual ~thread_pool();
+
+	void submit(std::function<void(void)> task);
+};
+
+class parfor {
+	std::mutex mutex;
+	std::condition_variable cond;
+
+	size_t num_inflight;
+
+public:
+	parfor() : num_inflight{0} {}
+
+	virtual ~parfor() {
+		wait();
+	}
+
+	void wait() {
+		std::unique_lock<std::mutex> mlock(mutex);
+		while(num_inflight > 0) {
+			cond.wait(mlock);
+		}
+	}
+
+	void submit(thread_pool &pool, std::function<void(void)> fn) {
+		pool.submit([this, fn]() {
+			fn();
+
+			std::unique_lock<std::mutex> mlock(mutex);
+			num_inflight -= 1;
+			mlock.unlock();
+
+			cond.notify_one();
+		});
+
+		std::unique_lock<std::mutex> mlock(mutex);
+		num_inflight += 1;
+	}
+};
+
+template<typename T>
+class asyncmap {
+	std::mutex mutex;
+	std::condition_variable cond;
+	std::deque<T> results;
+
+	size_t num_inflight;
+
+public:
+	asyncmap() : num_inflight{0} {}
+
+	virtual ~asyncmap() {
+		// need to wait for everything because they all have a reference to
+		// this and would likely crash when they tried to store their result
+		wait();
+	}
+
+	void wait() {
+		std::unique_lock<std::mutex> mlock(mutex);
+		while(num_inflight > 0) {
+			cond.wait(mlock);
+		}
+	}
+
+	void apply(thread_pool &pool, std::function<T(void)> fn) {
+		pool.submit([this, fn]() {
+			auto result = fn();
+
+			std::unique_lock<std::mutex> mlock(mutex);
+			num_inflight -= 1;
+			results.emplace_back(result);
+			cond.notify_one();
+		});
+
+		std::unique_lock<std::mutex> mlock(mutex);
+		num_inflight += 1;
+	}
+
+	bool empty() {
+		std::unique_lock<std::mutex> mlock(mutex);
+		return results.empty() && num_inflight == 0;
+	}
+
+	T get() {
+		std::unique_lock<std::mutex> mlock(mutex);
+		while (results.empty()) {
+			cond.wait(mlock);
+		}
+		auto result = results.front();
+		results.pop_front();
+		return result;
+	}
+};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -265,7 +265,7 @@ parse_csv_row(const std::string &row)
 	return fields;
 }
 
-#ifdef DOCTEST_LIBRARY_INCLUDED
+#ifdef INCLUDE_TESTS
 template<typename T> bool
 vectors_eq(const std::vector<T> &a, const std::vector<T> &b)
 {
@@ -273,15 +273,15 @@ vectors_eq(const std::vector<T> &a, const std::vector<T> &b)
 		std::equal(a.begin(), a.end(), b.begin());
 }
 
-TEST_SUITE("parse_csv_row") {
-	TEST_CASE("validate vectors_eq") {
+TEST_CASE("parse_csv_row") {
+	SECTION("validate vectors_eq") {
 		CHECK(vectors_eq<int>({}, {}));
 		CHECK(vectors_eq<int>({0}, {0}));
 		CHECK_FALSE(vectors_eq<int>({0}, {}));
 		CHECK_FALSE(vectors_eq<int>({}, {1}));
 		CHECK_FALSE(vectors_eq<int>({0}, {1}));
 	}
-	TEST_CASE("simple cases") {
+	SECTION("simple cases") {
 		CHECK(vectors_eq(parse_csv_row(""), {""}));
 		CHECK(vectors_eq(parse_csv_row("a"), {"a"}));
 		CHECK(vectors_eq(parse_csv_row(","), {"",""}));
@@ -289,7 +289,7 @@ TEST_SUITE("parse_csv_row") {
 		CHECK(vectors_eq(parse_csv_row("a, b"), {"a"," b"}));
 		CHECK(vectors_eq(parse_csv_row("a ,b"), {"a ","b"}));
 	}
-	TEST_CASE("double-quote escapes") {
+	SECTION("double-quote escapes") {
 		CHECK(vectors_eq(parse_csv_row("\"\""), {""}));
 		CHECK(vectors_eq(parse_csv_row("\",\""), {","}));
 		CHECK(vectors_eq(parse_csv_row("\"\"\"\""), {"\""}));


### PR DESCRIPTION
@makeclean noted in https://github.com/ukaea/overlap_checker/pull/11 that it wasn't obvious that progress was being made nor how long a user might be wait for a result

this code tries to fix that by reporting progress every 5 seconds, saying something like:

```
119.249 [Info] processed 2105 pairs (61%)
```

this log line says it's been working for ~2 minutes, this is an informational (hence visible by default, pass `-q` to hide this) and it's processed 2105 overlap checks and this is 61% of the total
