### PR TITLE
Fix parallel overlap checker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,7 @@ include_directories(SYSTEM ${OCC_INC})
 include_directories(SYSTEM "aixlog/include")
 include_directories(SYSTEM "cxx_argp")
 
-option(BUILD_TESTS "Whether to build tests" ON)
-if (BUILD_TESTS)
+if (BUILD_TESTING)
   add_subdirectory(Catch2)
 endif()
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,0 @@
-option('use_conan', type: 'boolean', value: true)
-option('opencascade', type: 'string', value: 'auto')
-option('conda_prefix', type: 'string', value: '')

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,7 @@ add_executable(imprint_solids imprint_solids.cpp $<TARGET_OBJECTS:shared>)
 
 add_executable(merge_solids merge_solids.cpp salome/geom_gluer.cpp $<TARGET_OBJECTS:shared>)
 
-if(BUILD_TESTS)
+if(BUILD_TESTING)
   add_executable(test_runner geometry.cpp utils.cpp thread_pool.cpp)
   target_compile_definitions(test_runner PUBLIC -DINCLUDE_TESTS)
   target_link_libraries(test_runner Catch2WithMain)

--- a/src/overlap_checker.cpp
+++ b/src/overlap_checker.cpp
@@ -132,35 +132,34 @@ main(int argc, char **argv)
 				num_parallel_jobs = std::thread::hardware_concurrency();
 				LOG(DEBUG)
 					<< "Using " << num_parallel_jobs << " threads for parallel computation\n";
-				return true;
+				return 0;
 			}
 
 			// sanity checking user input
 			const long parallel_job_limit = 9999;
+			long n;
+			size_t end;
 			try {
-				size_t end;
-				auto n = std::stol(arg, &end);
-				if (arg[end] != '\0') {
-					argp_error(
-						state, "trailing characters after number in '%s'",
-						arg);
-					return false;
-				}
-				// make sure the user isn't doing anything silly
-				if (n < 1 || n > parallel_job_limit) {
-					argp_error(
-						state, "number of parallel jobs should be between 1 and %li, not %li",
-						parallel_job_limit, n);
-					return false;
-				}
-				num_parallel_jobs = unsigned(n);
-				return true;
+				n = std::stol(arg, &end);
 			} catch(std::exception &err) {
 				argp_error(
 					state, "not a valid number: '%s'",
 					arg);
-				return false;
 			}
+			if (arg[end] != '\0') {
+				argp_error(
+					state, "trailing characters after number in '%s'",
+					arg);
+			}
+			// make sure the user isn't doing anything silly
+			else if (n < 1 || n > parallel_job_limit) {
+				argp_error(
+					state, "number of parallel jobs should be between 1 and %li, not %li",
+					parallel_job_limit, n);
+			} else {
+				num_parallel_jobs = unsigned(n);
+			}
+			return 0;
 		};
 
 		tool_argp_parser argp(1);

--- a/tests/demo_workflow.sh
+++ b/tests/demo_workflow.sh
@@ -23,7 +23,7 @@ step_to_brep "$source" "$brep" > "$geometry"
 
 echo "checking for intersecting solids" 1>&2
 
-overlap_checker "$brep" > "$overlaps"
+overlap_checker -j1 "$brep" > "$overlaps"
 
 if grep -q overlap "$overlaps"; then
     echo "writing overlapping solds into $common" 1>&2


### PR DESCRIPTION
was returning a `bool`, when I should have been returning an `error_t`