### PR TITLE
do something sensible when opencasde returns negative volumes

### DIFF
--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -114,7 +114,7 @@ volume_of_shape(const TopoDS_Shape& shape)
 {
 	const double volume = volume_of_shape_maybe_neg(shape);
 	if (volume < 0) {
- 		throw std::runtime_error("volume of shape less than zero");
+		throw std::runtime_error("volume of shape less than zero");
 	}
 	return volume;
 }

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -110,8 +110,8 @@ volume_of_shape(const TopoDS_Shape& shape)
 	const double volume = props.Mass();
 	if (volume < 0) {
 		LOG(WARNING)
-			<< "volume of shape less than zero ("
-			<< volume << ")\n";
+			<< "volume of shape (" << volume << ") less than zero, "
+			<< "taking the absolute value\n";
 	}
 	return fabs(volume);
 }

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -1,4 +1,5 @@
 #include <cstdlib>
+#include <math.h>
 #include <stdexcept>
 #include <sys/types.h>
 
@@ -108,9 +109,11 @@ volume_of_shape(const TopoDS_Shape& shape)
 	BRepGProp::VolumeProperties(shape, props);
 	const double volume = props.Mass();
 	if (volume < 0) {
-		throw std::runtime_error("volume of shape less than zero");
+		LOG(WARNING)
+			<< "volume of shape less than zero ("
+			<< volume << ")\n";
 	}
-	return volume;
+	return fabs(volume);
 }
 
 double


### PR DESCRIPTION
need to calculate volume for solids so that we can subtract the overlap off the smaller volume

opencascade sometimes produces a negative value when calculating this which isn't right.  James Cook suggested taking the absolute value of the volume, lets see if this does the right thing for their files

all the examples I've found so far have been large files which have made tracking down the source of this awkward.  if/when this can be done this change can be reverted back to a hard error