### PR TITLE
allow user to specify max time for pairwise tests

### DIFF
--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -114,7 +114,7 @@ volume_of_shape(const TopoDS_Shape& shape)
 {
 	const double volume = volume_of_shape_maybe_neg(shape);
 	if (volume < 0) {
- 		throw std::runtime_error("volume of shape less than zero");
+		throw std::runtime_error("volume of shape less than zero");
 	}
 	return volume;
 }

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -110,8 +110,8 @@ volume_of_shape(const TopoDS_Shape& shape)
 	const double volume = props.Mass();
 	if (volume < 0) {
 		LOG(WARNING)
-			<< "volume of shape less than zero ("
-			<< volume << ")\n";
+			<< "volume of shape (" << volume << ") less than zero, "
+			<< "taking the absolute value\n";
 	}
 	return fabs(volume);
 }

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -1,4 +1,5 @@
 #include <cstdlib>
+#include <math.h>
 #include <stdexcept>
 #include <sys/types.h>
 
@@ -108,9 +109,11 @@ volume_of_shape(const TopoDS_Shape& shape)
 	BRepGProp::VolumeProperties(shape, props);
 	const double volume = props.Mass();
 	if (volume < 0) {
-		throw std::runtime_error("volume of shape less than zero");
+		LOG(WARNING)
+			<< "volume of shape less than zero ("
+			<< volume << ")\n";
 	}
-	return volume;
+	return fabs(volume);
 }
 
 double

--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -68,6 +68,9 @@ enum class intersect_status {
 	// something failed within OCCT, a different fuzzy value might help
 	failed,
 
+	// took too long to perform pave operation
+	timeout,
+
 	// null intersection
 	distinct,
 
@@ -90,10 +93,15 @@ struct intersect_result {
 
 	// only valid if result == overlap
 	double vol_common, vol_cut, vol_cut12;
+
+	// how long did the pavefiller operation take
+	double pave_time_seconds;
 };
 
+// pave time of zero disables timeout handling
 intersect_result classify_solid_intersection(
-	const TopoDS_Shape& shape, const TopoDS_Shape& tool, double fuzzy_value);
+	const TopoDS_Shape& shape, const TopoDS_Shape& tool,
+	double fuzzy_value, unsigned pave_time_millisecs=0);
 
 
 enum class imprint_status {

--- a/src/merge_solids.cpp
+++ b/src/merge_solids.cpp
@@ -9,8 +9,8 @@
 #include <TopoDS_Iterator.hxx>
 #include <TopoDS_Builder.hxx>
 #include <TopoDS_Compound.hxx>
-#include "TopoDS_Solid.hxx"
-#include "TopoDS_Shape.hxx"
+#include <TopoDS_Solid.hxx>
+#include <TopoDS_Shape.hxx>
 
 #include "salome/geom_gluer.hxx"
 

--- a/src/overlap_checker.cpp
+++ b/src/overlap_checker.cpp
@@ -1,5 +1,6 @@
 #include <cassert>
 #include <chrono>
+#include <cstdlib>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -46,8 +47,16 @@ shape_classifier(const worker_state& state, size_t hi, size_t lo)
 				<< "warnings, retrying with tolerance=" << fuzzy_value << '\n';
 		}
 
-		result = classify_solid_intersection(
-			shape, tool, fuzzy_value);
+		try {
+			result = classify_solid_intersection(
+				shape, tool, fuzzy_value);
+		} catch (const std::exception &ex) {
+			LOG(FATAL)
+				<< indexpair_to_string(hi, lo)
+				<< " classifying intersection failed: "
+				<< ex.what() << '\n';
+			abort();
+		}
 
 		// try again with less fuzz
 		if (result.status != intersect_status::failed) {

--- a/src/overlap_checker.cpp
+++ b/src/overlap_checker.cpp
@@ -8,6 +8,7 @@
 
 #include <BRepBndLib.hxx>
 #include <Bnd_OBB.hxx>
+#include <OSD_Parallel.hxx>
 
 #include <cxx_argp_parser.h>
 #include <aixlog.hpp>
@@ -86,6 +87,7 @@ main(int argc, char **argv)
 	configure_aixlog();
 
 	std::string path_in;
+	bool enable_intel_tbb = false;
 	unsigned num_parallel_jobs = 1;
 	double
 		bbox_clearance = 0.5,
@@ -172,6 +174,8 @@ main(int argc, char **argv)
 			{"imprint-tolerance", 1025, "T", 0, help_imp_tol.c_str(), 0}, imprint_tolerances);
 		argp.add_option(
 			{"max-common-volume-ratio", 1026, "R", 0, help_max_common.c_str(), 0}, max_common_volume_ratio);
+		argp.add_option(
+			{"enable-intel_tbb", 1027, 0, 0, "Enable OCCT use of Intel TBB, disabled by default as it gets in the way of our parallelism", -1}, enable_intel_tbb);
 
 		if (!argp.parse(argc, argv, usage, doc)) {
 			return 1;
@@ -202,6 +206,10 @@ main(int argc, char **argv)
 			return 1;
 		}
 	}
+
+	// flags to control OCCT's unwanted use of background threads
+	OSD_Parallel::SetUseOcctThreads (!enable_intel_tbb);
+	LOG(TRACE) << "OSD_Parallel::ToUseOcctThreads() = " << OSD_Parallel::ToUseOcctThreads() << "\n";
 
 	document doc;
 	doc.load_brep_file(path_in.c_str());

--- a/src/overlap_checker.cpp
+++ b/src/overlap_checker.cpp
@@ -286,8 +286,9 @@ main(int argc, char **argv)
 
 			if (report_when < std::chrono::steady_clock::now()) {
 				LOG(INFO)
-					<< "processed " << num_processed << " pairs ("
-					<< (num_processed * 100) / num_to_process << "%)\n";
+					<< "processed "
+					<< (num_processed * 100) / num_to_process << "% of pairs, "
+					<< (num_to_process - num_processed) << " remain\n";
 
 				report_when += reporting_interval;
 			}


### PR DESCRIPTION
should be much better than current hack of externally giving some maximum time for the whole operation.  this scales appropriately with the number of object tests needing to be performed