### PR TITLE
Fix demo_workflow.sh test

### DIFF
--- a/tests/demo_workflow.sh
+++ b/tests/demo_workflow.sh
@@ -7,6 +7,8 @@ if [ ! -f "${1-}" ]; then
     exit 1
 fi
 
+PATH=.:$PATH
+
 source="$1"
 base="${source##*/}"
 base="${base%.*}"


### PR DESCRIPTION
`ctest` was failing with the tools not found.  Adding `PATH=.:$PATH` seems to fix the test.

Of course, there are other ways this could be fixed.  Maybe it would be better to find a way to make ctest set the path before running the script?