### PR TITLE
Optionally specify library folder path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ endif()
 find_path(OCC_INC "Standard_Version.hxx" HINTS "/usr/include/opencascade" REQUIRED)
 include_directories(SYSTEM ${OCC_INC})
 
+find_path(OCC_LIB "")
+link_directories(SYSTEM ${OCC_LIB})
 # pull in our external libraries
 include_directories(SYSTEM "aixlog/include")
 include_directories(SYSTEM "cxx_argp")


### PR DESCRIPTION
When building with custom located OCCT (a mess of nested pyenv conda and conda envs) after specifying the OCC_INC directory the linker fails because the library directory is not found.

This adds the OCC_LIB variable to specify that. 

If there is a better way please let me know!